### PR TITLE
:sparkles: Add authentication middleware to logout route

### DIFF
--- a/src/routes/api/v1/auth.ts
+++ b/src/routes/api/v1/auth.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 import { AuthController } from '../../../controllers/authController';
+import { authenticate } from '../../../middlewares/authenticate';
 
 const router: Router = Router();
 
 router.post('/login', AuthController.login);
-router.post('/logout', AuthController.logout); // TODO Requires authentication middleware for protection
+router.post('/logout', authenticate, AuthController.logout);
 
 export default router;


### PR DESCRIPTION
Protect the logout endpoint by adding the `authenticate` middleware, ensuring only authenticated users can log out.