### PR TITLE
:wrench: Make packing list schema fields optional

### DIFF
--- a/src/schemas/packingListSchema.ts
+++ b/src/schemas/packingListSchema.ts
@@ -11,11 +11,11 @@ import { z, ZodError } from 'zod';
 const packingListRowSchema = z
   .object({
     LINE: z.number(),
-    'SKU MIN': z.string(),
-    MAKE: z.string(),
+    'SKU MIN': z.string().optional(),
+    MAKE: z.string().optional(),
     MODEL: z.string(),
     'DESCRIPTION MIN': z.string(),
-    'QTY REQ MATCH': z.number(),
+    'QTY REQ MATCH': z.number().optional(),
     'QTY ALLOC': z
       .number()
       .nullish()

--- a/tests/unit/processPackingListData.test.ts
+++ b/tests/unit/processPackingListData.test.ts
@@ -136,11 +136,8 @@ describe('PackingListService', () => {
       },
       {
         LINE: 2,
-        'SKU MIN': '',
-        MAKE: 'Make2',
         MODEL: 'Model2',
         'DESCRIPTION MIN': '',
-        'QTY REQ MATCH': 20,
         'QTY ALLOC': 20,
         ORIGIN: 'Origin2',
         CTN: '11-20',


### PR DESCRIPTION
Make 'SKU MIN', 'MAKE', and 'QTY REQ MATCH' fields optional in the packing list row schema to accommodate variations in input data.