### PR TITLE
✨ [company]: Add company access control middleware

### DIFF
--- a/docs/middlewares/companyAccess.md
+++ b/docs/middlewares/companyAccess.md
@@ -1,0 +1,235 @@
+# Company Access Control Middleware
+
+This document explains the use of company access control middlewares to secure endpoints in a B2B context.
+
+## 🎯 Objective
+
+Ensure data isolation by company while allowing System Admins (role `ADMIN`) to have full access to the system.
+
+## 🛡️ Available Middlewares
+
+### 1. `requireOwnCompanyOrSystemAdmin()`
+
+**Usage:** Automatic filtering by company, except for System Admins.
+
+```typescript
+import { requireOwnCompanyOrSystemAdmin } from '../middlewares/companyAccess';
+
+router.get(
+  '/',
+  authenticate,
+  authorize(['company:read']),
+  requireOwnCompanyOrSystemAdmin(),
+  companyController.getAllCompanies
+);
+```
+
+**Behavior:**
+
+- **System Admin (ADMIN):** Full access, no filtering
+- **Other roles:** `req.companyFilter = { companyId: req.user.companyId }`
+
+### 2. `requireOwnCompanyOnly()`
+
+**Usage:** Enforces filtering by company for ALL users.
+
+```typescript
+import { requireOwnCompanyOnly } from '../middlewares/companyAccess';
+
+router.get(
+  '/sensitive-data',
+  authenticate,
+  authorize(['data:read']),
+  requireOwnCompanyOnly(),
+  dataController.getSensitiveData
+);
+```
+
+**Behavior:**
+
+- **All roles:** `req.companyFilter = { companyId: req.user.companyId }`
+
+### 3. `validateCompanyAccess()`
+
+**Usage:** Validates access to resources via route parameters.
+
+```typescript
+import { validateCompanyAccess } from '../middlewares/companyAccess';
+
+router.get(
+  '/:id',
+  authenticate,
+  authorize(['company:read']),
+  validateCompanyAccess(),
+  companyController.getCompanyById
+);
+```
+
+**Behavior:**
+
+- **System Admin:** Can access any company
+- **Other roles:** Can only access their own company
+- **403 Error** if attempting to access another company
+
+### 4. `validateCompanyAccessInBody()`
+
+**Usage:** Validates access to resources via the request body.
+
+```typescript
+import { validateCompanyAccessInBody } from '../middlewares/companyAccess';
+
+router.put(
+  '/:id',
+  authenticate,
+  authorize(['company:update']),
+  validateCompanyAccessInBody(),
+  companyController.updateCompany
+);
+```
+
+**Behavior:**
+
+- **System Admin:** Can modify any company
+- **Other roles:** Can only modify their own company
+- **403 Error** if attempting to modify another company
+
+## 🔧 Usage in Services
+
+The middlewares add `req.companyFilter` that services can use:
+
+```typescript
+// In a service
+async getAllCompanies(req: Request): Promise<Company[]> {
+    if (req.companyFilter?.companyId) {
+        // Regular user: filter by their company
+        return this.companyRepository.findMany({
+            where: { id: req.companyFilter.companyId }
+        });
+    } else {
+        // System Admin: return all companies
+        return this.companyRepository.findMany();
+    }
+}
+```
+
+## 📋 Application Examples
+
+### Complete Company Routes
+
+```typescript
+// src/routes/api/v1/company.ts
+import {
+  requireOwnCompanyOrSystemAdmin,
+  validateCompanyAccess,
+  validateCompanyAccessInBody,
+} from '../../../middlewares/companyAccess';
+
+// Creation: validate companyId in the body
+router.post(
+  '/',
+  authenticate,
+  authorize(['company:create']),
+  validateCompanyAccessInBody(),
+  companyController.create
+);
+
+// List: automatic filtering
+router.get(
+  '/',
+  authenticate,
+  authorize(['company:read']),
+  requireOwnCompanyOrSystemAdmin(),
+  companyController.getAllCompanies
+);
+
+// Current company: no filtering needed
+router.get(
+  '/current',
+  authenticate,
+  authorize(['company:read']),
+  companyController.getCurrentCompany
+);
+
+// By ID: validate access
+router.get(
+  '/:id',
+  authenticate,
+  authorize(['company:read']),
+  validateCompanyAccess(),
+  companyController.getCompanyById
+);
+
+// Update: validate parameter AND body
+router.put(
+  '/:id',
+  authenticate,
+  authorize(['company:update']),
+  validateCompanyAccess(),
+  validateCompanyAccessInBody(),
+  companyController.updateCompany
+);
+
+// Deletion: validate access
+router.delete(
+  '/:id',
+  authenticate,
+  authorize(['company:delete']),
+  validateCompanyAccess(),
+  companyController.deleteCompany
+);
+```
+
+## 🎯 Use Cases
+
+### Scenario 1: System Admin
+
+```typescript
+// User: admin@test.com (role ADMIN)
+// GET /api/v1/company
+// → Returns ALL companies (no filtering)
+
+// GET /api/v1/company/any-company-id
+// → Access allowed to any company
+```
+
+### Scenario 2: Company Manager
+
+```typescript
+// User: manager@company123.com (role MANAGER, companyId: company-123)
+// GET /api/v1/company
+// → req.companyFilter = { companyId: 'company-123' }
+// → Returns only company-123
+
+// GET /api/v1/company/company-456
+// → 403 Error (attempt to access another company)
+
+// GET /api/v1/company/company-123
+// → Access allowed (their own company)
+```
+
+### Scenario 3: Standard User
+
+```typescript
+// User: user@company789.com (role USER, companyId: company-789)
+// GET /api/v1/company/current
+// → Returns company-789
+
+// PUT /api/v1/company/company-789 { companyId: 'company-456' }
+// → 403 Error (attempt to modify another company)
+```
+
+## 🔒 Security
+
+These middlewares ensure:
+
+- **Data isolation** by company
+- **Privileged access** for System Admins
+- **Strict validation** of cross-company access attempts
+- **Transparency** for developers (via `req.companyFilter`)
+
+## 🧪 Tests
+
+All middlewares are covered by comprehensive unit tests in:
+
+- `tests/middlewares/companyAccess.test.ts`
+- `tests/controllers/companyController.getCurrentCompany.test.ts`

--- a/src/controllers/companyController.ts
+++ b/src/controllers/companyController.ts
@@ -49,6 +49,29 @@ export class CompanyController extends BaseController {
     }
   };
 
+  getCurrentCompany = async (
+    req: Request,
+    res: Response
+  ): Promise<Response> => {
+    try {
+      if (!req.user?.companyId) {
+        return res.status(400).json({ message: 'User company not found' });
+      }
+
+      const company = await this.companyService.getCompanyById(
+        req.user.companyId
+      );
+
+      if (!company) {
+        return res.status(404).json({ message: 'Company not found' });
+      }
+
+      return res.status(200).json(company);
+    } catch (error: unknown) {
+      return this.handleError(res, error, mapCompanyError);
+    }
+  };
+
   updateCompany = async (req: Request, res: Response): Promise<Response> => {
     try {
       const { id } = req.params;

--- a/src/middlewares/companyAccess.ts
+++ b/src/middlewares/companyAccess.ts
@@ -1,0 +1,103 @@
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Middleware that grants full access to System Admins (ADMIN)
+ * and filters by companyId for other users
+ */
+export const requireOwnCompanyOrSystemAdmin = () => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.user) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+
+    // If System Admin (role ADMIN): full access without filtering
+    if (req.user.isSystemAdmin) {
+      return next();
+    }
+
+    // For regular users: filter by their company
+    req.companyFilter = { companyId: req.user.companyId };
+    next();
+  };
+};
+
+/**
+ * Middleware that enforces company filtering for ALL users
+ * (even System Admins)
+ */
+export const requireOwnCompanyOnly = () => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.user) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+
+    // Enforce company filtering for everyone
+    req.companyFilter = { companyId: req.user.companyId };
+    next();
+  };
+};
+
+/**
+ * Middleware that validates the user only accesses data
+ * from their own company via route parameters
+ */
+export const validateCompanyAccess = () => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.user) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+
+    const { companyId } = req.params;
+
+    // If no companyId in the parameters, continue
+    if (!companyId) {
+      return next();
+    }
+
+    // If System Admin: access allowed to any company
+    if (req.user.isSystemAdmin) {
+      return next();
+    }
+
+    // Ensure the user only accesses their own company
+    if (companyId !== req.user.companyId) {
+      return res.status(403).json({
+        message: 'Access denied: cannot access other company data',
+      });
+    }
+
+    next();
+  };
+};
+
+/**
+ * Middleware that validates access to company resources in the request body
+ */
+export const validateCompanyAccessInBody = () => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.user) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+
+    const { companyId } = req.body;
+
+    // If no companyId in the body, continue
+    if (!companyId) {
+      return next();
+    }
+
+    // If System Admin: access allowed to any company
+    if (req.user.isSystemAdmin) {
+      return next();
+    }
+
+    // Ensure the user only modifies their own company
+    if (companyId !== req.user.companyId) {
+      return res.status(403).json({
+        message: 'Access denied: cannot modify other company data',
+      });
+    }
+
+    next();
+  };
+};

--- a/src/routes/api/v1/company.ts
+++ b/src/routes/api/v1/company.ts
@@ -2,6 +2,11 @@ import { Router } from 'express';
 import { CompanyController } from '../../../controllers/companyController';
 import { authenticate } from '../../../middlewares/authenticate';
 import { authorize } from '../../../middlewares/authorize';
+import {
+  requireOwnCompanyOrSystemAdmin,
+  validateCompanyAccess,
+  validateCompanyAccessInBody,
+} from '../../../middlewares/companyAccess';
 import { container } from 'tsyringe';
 
 const router: Router = Router();
@@ -11,30 +16,42 @@ router.post(
   '/',
   authenticate,
   authorize(['company:create']),
+  validateCompanyAccessInBody(),
   companyController.create
 );
 router.get(
   '/',
   authenticate,
   authorize(['company:read']),
+  requireOwnCompanyOrSystemAdmin(),
   companyController.getAllCompanies
+);
+router.get(
+  '/current',
+  authenticate,
+  authorize(['company:read']),
+  companyController.getCurrentCompany
 );
 router.get(
   '/:id',
   authenticate,
   authorize(['company:read']),
+  validateCompanyAccess(),
   companyController.getCompanyById
 );
 router.put(
   '/:id',
   authenticate,
   authorize(['company:update']),
+  validateCompanyAccess(),
+  validateCompanyAccessInBody(),
   companyController.updateCompany
 );
 router.delete(
   '/:id',
   authenticate,
   authorize(['company:delete']),
+  validateCompanyAccess(),
   companyController.deleteCompany
 );
 

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -4,6 +4,9 @@ declare global {
   namespace Express {
     interface Request {
       user?: TokenPayload; // Make user property optional again
+      companyFilter?: {
+        companyId?: string;
+      };
     }
   }
 }

--- a/tests/controllers/companyController.getCurrentCompany.test.ts
+++ b/tests/controllers/companyController.getCurrentCompany.test.ts
@@ -1,0 +1,163 @@
+import { Request, Response } from 'express';
+import { CompanyController } from '../../src/controllers/companyController';
+import { ICompanyRepository } from '../../src/repositories/company/ICompanyRepository';
+import { Company } from '../../src/generated/prisma';
+import { TokenPayload } from '../../src/types/auth';
+
+describe('CompanyController - getCurrentCompany', () => {
+  let companyController: CompanyController;
+  let mockCompanyService: jest.Mocked<ICompanyRepository>;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    mockCompanyService = {
+      getCompanyById: jest.fn(),
+    } as Partial<
+      jest.Mocked<ICompanyRepository>
+    > as jest.Mocked<ICompanyRepository>;
+
+    companyController = new CompanyController(mockCompanyService);
+
+    req = {
+      user: undefined,
+    };
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+  });
+
+  it('should return 400 if user has no companyId', async () => {
+    req.user = {
+      userId: 'user-1',
+      companyId: undefined,
+      roleId: 'role-1',
+      roleName: 'USER',
+      permissions: ['company:read'],
+      isSystemAdmin: false,
+    } as Partial<TokenPayload> as TokenPayload;
+
+    await companyController.getCurrentCompany(req as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'User company not found',
+    });
+    expect(mockCompanyService.getCompanyById).not.toHaveBeenCalled();
+  });
+
+  it('should return 404 if company is not found', async () => {
+    req.user = {
+      userId: 'user-1',
+      companyId: 'company-123',
+      roleId: 'role-1',
+      roleName: 'USER',
+      permissions: ['company:read'],
+      isSystemAdmin: false,
+    } as TokenPayload;
+
+    mockCompanyService.getCompanyById.mockResolvedValue(null);
+
+    await companyController.getCurrentCompany(req as Request, res as Response);
+
+    expect(mockCompanyService.getCompanyById).toHaveBeenCalledWith(
+      'company-123'
+    );
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Company not found',
+    });
+  });
+
+  it('should return company data for authenticated user', async () => {
+    const mockCompany: Company = {
+      id: 'company-123',
+      name: 'Test Company',
+      description: 'Test Description',
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    req.user = {
+      userId: 'user-1',
+      companyId: 'company-123',
+      roleId: 'role-1',
+      roleName: 'USER',
+      permissions: ['company:read'],
+      isSystemAdmin: false,
+    } as TokenPayload;
+
+    mockCompanyService.getCompanyById.mockResolvedValue(mockCompany);
+
+    await companyController.getCurrentCompany(req as Request, res as Response);
+
+    expect(mockCompanyService.getCompanyById).toHaveBeenCalledWith(
+      'company-123'
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(mockCompany);
+  });
+
+  it('should work for System Admin', async () => {
+    const mockCompany: Company = {
+      id: 'company-456',
+      name: 'Admin Company',
+      description: 'Admin Description',
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    req.user = {
+      userId: 'admin-1',
+      companyId: 'company-456',
+      roleId: 'role-admin',
+      roleName: 'ADMIN',
+      permissions: ['company:read', 'company:create'],
+      isSystemAdmin: true,
+    } as TokenPayload;
+
+    mockCompanyService.getCompanyById.mockResolvedValue(mockCompany);
+
+    await companyController.getCurrentCompany(req as Request, res as Response);
+
+    expect(mockCompanyService.getCompanyById).toHaveBeenCalledWith(
+      'company-456'
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(mockCompany);
+  });
+
+  it('should work for Manager', async () => {
+    const mockCompany: Company = {
+      id: 'company-789',
+      name: 'Manager Company',
+      description: 'Manager Description',
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    req.user = {
+      userId: 'manager-1',
+      companyId: 'company-789',
+      roleId: 'role-manager',
+      roleName: 'MANAGER',
+      permissions: ['company:read', 'user:manage'],
+      isSystemAdmin: false,
+    } as TokenPayload;
+
+    mockCompanyService.getCompanyById.mockResolvedValue(mockCompany);
+
+    await companyController.getCurrentCompany(req as Request, res as Response);
+
+    expect(mockCompanyService.getCompanyById).toHaveBeenCalledWith(
+      'company-789'
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(mockCompany);
+  });
+});

--- a/tests/middlewares/companyAccess.test.ts
+++ b/tests/middlewares/companyAccess.test.ts
@@ -1,0 +1,322 @@
+import { Request, Response, NextFunction } from 'express';
+import {
+  requireOwnCompanyOrSystemAdmin,
+  requireOwnCompanyOnly,
+  validateCompanyAccess,
+  validateCompanyAccessInBody,
+} from '../../src/middlewares/companyAccess';
+import { TokenPayload } from '../../src/types/auth';
+
+describe('Company Access Middleware', () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: jest.Mock;
+
+  beforeEach(() => {
+    req = {
+      user: undefined,
+      params: {},
+      body: {},
+      companyFilter: undefined,
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    next = jest.fn();
+  });
+
+  describe('requireOwnCompanyOrSystemAdmin', () => {
+    it('should return 401 if user is not authenticated', () => {
+      const middleware = requireOwnCompanyOrSystemAdmin();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Authentication required',
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should allow System Admin without filtering', () => {
+      req.user = {
+        userId: 'admin-1',
+        companyId: 'company-1',
+        roleId: 'role-admin',
+        roleName: 'ADMIN',
+        permissions: ['company:read'],
+        isSystemAdmin: true,
+      } as TokenPayload;
+
+      const middleware = requireOwnCompanyOrSystemAdmin();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(req.companyFilter).toBeUndefined();
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should filter by companyId for normal users', () => {
+      req.user = {
+        userId: 'user-1',
+        companyId: 'company-123',
+        roleId: 'role-user',
+        roleName: 'USER',
+        permissions: ['packing_list:read'],
+        isSystemAdmin: false,
+      } as TokenPayload;
+
+      const middleware = requireOwnCompanyOrSystemAdmin();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(req.companyFilter).toEqual({ companyId: 'company-123' });
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should filter by companyId for managers', () => {
+      req.user = {
+        userId: 'manager-1',
+        companyId: 'company-456',
+        roleId: 'role-manager',
+        roleName: 'MANAGER',
+        permissions: ['user:manage', 'packing_list:read'],
+        isSystemAdmin: false,
+      } as TokenPayload;
+
+      const middleware = requireOwnCompanyOrSystemAdmin();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(req.companyFilter).toEqual({ companyId: 'company-456' });
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requireOwnCompanyOnly', () => {
+    it('should return 401 if user is not authenticated', () => {
+      const middleware = requireOwnCompanyOnly();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Authentication required',
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should filter even System Admins by their companyId', () => {
+      req.user = {
+        userId: 'admin-1',
+        companyId: 'company-1',
+        roleId: 'role-admin',
+        roleName: 'ADMIN',
+        permissions: ['company:read'],
+        isSystemAdmin: true,
+      } as TokenPayload;
+
+      const middleware = requireOwnCompanyOnly();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(req.companyFilter).toEqual({ companyId: 'company-1' });
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should filter normal users by their companyId', () => {
+      req.user = {
+        userId: 'user-1',
+        companyId: 'company-789',
+        roleId: 'role-user',
+        roleName: 'USER',
+        permissions: ['packing_list:read'],
+        isSystemAdmin: false,
+      } as TokenPayload;
+
+      const middleware = requireOwnCompanyOnly();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(req.companyFilter).toEqual({ companyId: 'company-789' });
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validateCompanyAccess', () => {
+    it('should return 401 if user is not authenticated', () => {
+      req.params = { companyId: 'company-123' };
+
+      const middleware = validateCompanyAccess();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Authentication required',
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should continue if no companyId in params', () => {
+      req.user = {
+        userId: 'user-1',
+        companyId: 'company-123',
+        roleId: 'role-user',
+        roleName: 'USER',
+        permissions: ['packing_list:read'],
+        isSystemAdmin: false,
+      } as TokenPayload;
+
+      const middleware = validateCompanyAccess();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should allow System Admin to access any company', () => {
+      req.user = {
+        userId: 'admin-1',
+        companyId: 'company-1',
+        roleId: 'role-admin',
+        roleName: 'ADMIN',
+        permissions: ['company:read'],
+        isSystemAdmin: true,
+      } as TokenPayload;
+      req.params = { companyId: 'company-999' };
+
+      const middleware = validateCompanyAccess();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should allow user to access their own company', () => {
+      req.user = {
+        userId: 'user-1',
+        companyId: 'company-123',
+        roleId: 'role-user',
+        roleName: 'USER',
+        permissions: ['packing_list:read'],
+        isSystemAdmin: false,
+      } as TokenPayload;
+      req.params = { companyId: 'company-123' };
+
+      const middleware = validateCompanyAccess();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should deny user access to other company', () => {
+      req.user = {
+        userId: 'user-1',
+        companyId: 'company-123',
+        roleId: 'role-user',
+        roleName: 'USER',
+        permissions: ['packing_list:read'],
+        isSystemAdmin: false,
+      } as TokenPayload;
+      req.params = { companyId: 'company-456' };
+
+      const middleware = validateCompanyAccess();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Access denied: cannot access other company data',
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validateCompanyAccessInBody', () => {
+    it('should return 401 if user is not authenticated', () => {
+      req.body = { companyId: 'company-123' };
+
+      const middleware = validateCompanyAccessInBody();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Authentication required',
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should continue if no companyId in body', () => {
+      req.user = {
+        userId: 'user-1',
+        companyId: 'company-123',
+        roleId: 'role-user',
+        roleName: 'USER',
+        permissions: ['packing_list:read'],
+        isSystemAdmin: false,
+      } as TokenPayload;
+
+      const middleware = validateCompanyAccessInBody();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should allow System Admin to modify any company data', () => {
+      req.user = {
+        userId: 'admin-1',
+        companyId: 'company-1',
+        roleId: 'role-admin',
+        roleName: 'ADMIN',
+        permissions: ['company:update'],
+        isSystemAdmin: true,
+      } as TokenPayload;
+      req.body = { companyId: 'company-999', name: 'Updated Company' };
+
+      const middleware = validateCompanyAccessInBody();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should allow user to modify their own company data', () => {
+      req.user = {
+        userId: 'manager-1',
+        companyId: 'company-123',
+        roleId: 'role-manager',
+        roleName: 'MANAGER',
+        permissions: ['company:update'],
+        isSystemAdmin: false,
+      } as TokenPayload;
+      req.body = { companyId: 'company-123', name: 'Updated Company' };
+
+      const middleware = validateCompanyAccessInBody();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should deny user modification of other company data', () => {
+      req.user = {
+        userId: 'manager-1',
+        companyId: 'company-123',
+        roleId: 'role-manager',
+        roleName: 'MANAGER',
+        permissions: ['company:update'],
+        isSystemAdmin: false,
+      } as TokenPayload;
+      req.body = { companyId: 'company-456', name: 'Malicious Update' };
+
+      const middleware = validateCompanyAccessInBody();
+      middleware(req as Request, res as Response, next as NextFunction);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Access denied: cannot modify other company data',
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
- Create requireOwnCompanyOrSystemAdmin() middleware for automatic filtering
- Create validateCompanyAccess() middleware for parameter validation
- Create validateCompanyAccessInBody() middleware for body validation
- Add GET /current endpoint to retrieve user's company
- Extend Request interface with companyFilter
- Complete test coverage for all middlewares (22 tests)
- Comprehensive middleware documentation

B2B Security:
- System Admins (ADMIN): full access without filtering
- Regular users: access limited to their company
- Strict validation of cross-company access attempts