### PR TITLE
🔧 [company]: Implement company service filtering

### DIFF
--- a/src/controllers/companyController.ts
+++ b/src/controllers/companyController.ts
@@ -42,7 +42,9 @@ export class CompanyController extends BaseController {
 
   getAllCompanies = async (req: Request, res: Response): Promise<Response> => {
     try {
-      const companies = await this.companyService.getAllCompanies();
+      const companies = await this.companyService.getAllCompanies(
+        req.companyFilter
+      );
       return res.status(200).json(companies);
     } catch (error: unknown) {
       return this.handleError(res, error, mapCompanyError);

--- a/src/repositories/company/ICompanyRepository.ts
+++ b/src/repositories/company/ICompanyRepository.ts
@@ -4,7 +4,18 @@ export interface ICompanyRepository {
   create(data: Prisma.CompanyCreateInput): Promise<Company>;
   getCompanyById(id: string): Promise<Company | null>;
   getCompanyByName(name: string): Promise<Company | null>;
-  getAllCompanies(): Promise<Company[]>;
+  getAllCompanies(filter?: { companyId?: string }): Promise<Company[]>;
   updateCompany(id: string, data: Prisma.CompanyUpdateInput): Promise<Company>;
   deleteCompany(id: string): Promise<Company>;
+
+  // Nouvelles méthodes pour le filtrage par utilisateur
+  getCompaniesByUser(
+    userId: string,
+    isSystemAdmin: boolean
+  ): Promise<Company[]>;
+  canUserAccessCompany(
+    companyId: string,
+    userId: string,
+    isSystemAdmin: boolean
+  ): Promise<boolean>;
 }

--- a/src/services/company/companyService.ts
+++ b/src/services/company/companyService.ts
@@ -34,8 +34,8 @@ export class CompanyService implements ICompanyRepository {
     return this.companyRepository.getCompanyByName(name);
   }
 
-  async getAllCompanies(): Promise<Company[]> {
-    return this.companyRepository.getAllCompanies();
+  async getAllCompanies(filter?: { companyId?: string }): Promise<Company[]> {
+    return this.companyRepository.getAllCompanies(filter);
   }
 
   async updateCompany(
@@ -47,5 +47,24 @@ export class CompanyService implements ICompanyRepository {
 
   async deleteCompany(id: string): Promise<Company> {
     return this.companyRepository.deleteCompany(id);
+  }
+
+  async getCompaniesByUser(
+    userId: string,
+    isSystemAdmin: boolean
+  ): Promise<Company[]> {
+    return this.companyRepository.getCompaniesByUser(userId, isSystemAdmin);
+  }
+
+  async canUserAccessCompany(
+    companyId: string,
+    userId: string,
+    isSystemAdmin: boolean
+  ): Promise<boolean> {
+    return this.companyRepository.canUserAccessCompany(
+      companyId,
+      userId,
+      isSystemAdmin
+    );
   }
 }

--- a/tests/controllers/companyController.test.ts
+++ b/tests/controllers/companyController.test.ts
@@ -25,6 +25,8 @@ describe('CompanyController with mocked service', () => {
       updateCompany: jest.fn(),
       deleteCompany: jest.fn(),
       getCompanyByName: jest.fn(),
+      getCompaniesByUser: jest.fn(),
+      canUserAccessCompany: jest.fn(),
     };
     controller = new CompanyController(mockService);
     res = createMockResponse();

--- a/tests/integration/companyFiltering.integration.test.ts
+++ b/tests/integration/companyFiltering.integration.test.ts
@@ -1,0 +1,243 @@
+import { Request, Response } from 'express';
+import { CompanyController } from '../../src/controllers/companyController';
+import { TokenPayload } from '../../src/types/auth';
+import { ICompanyRepository } from '../../src/repositories/company/ICompanyRepository';
+
+describe('Company Filtering Integration', () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let mockCompanyService: jest.Mocked<ICompanyRepository>;
+  let companyController: CompanyController;
+
+  beforeEach(() => {
+    mockCompanyService = {
+      getAllCompanies: jest.fn(),
+      getCompanyById: jest.fn(),
+      create: jest.fn(),
+      updateCompany: jest.fn(),
+      deleteCompany: jest.fn(),
+      getCompanyByName: jest.fn(),
+      getCompaniesByUser: jest.fn(),
+      canUserAccessCompany: jest.fn(),
+    };
+
+    companyController = new CompanyController(mockCompanyService);
+
+    req = {
+      user: undefined,
+      companyFilter: undefined,
+      params: {},
+      body: {},
+    };
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+  });
+
+  describe('getAllCompanies with filtering', () => {
+    it('should call service with no filter for System Admin', async () => {
+      // System Admin user
+      req.user = {
+        userId: 'admin-1',
+        companyId: 'admin-company',
+        roleId: 'role-admin',
+        roleName: 'ADMIN',
+        permissions: ['company:read'],
+        isSystemAdmin: true,
+      } as TokenPayload;
+
+      // No companyFilter set (System Admin bypass)
+      req.companyFilter = undefined;
+
+      const mockCompanies = [
+        {
+          id: 'company-1',
+          name: 'Company 1',
+          description: 'Description 1',
+          isActive: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'company-2',
+          name: 'Company 2',
+          description: 'Description 2',
+          isActive: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      mockCompanyService.getAllCompanies.mockResolvedValue(mockCompanies);
+
+      await companyController.getAllCompanies(req as Request, res as Response);
+
+      expect(mockCompanyService.getAllCompanies).toHaveBeenCalledWith(
+        undefined
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(mockCompanies);
+    });
+
+    it('should call service with companyFilter for normal user', async () => {
+      // Normal user
+      req.user = {
+        userId: 'user-1',
+        companyId: 'user-company-123',
+        roleId: 'role-user',
+        roleName: 'USER',
+        permissions: ['company:read'],
+        isSystemAdmin: false,
+      } as TokenPayload;
+
+      // companyFilter set by middleware
+      req.companyFilter = { companyId: 'user-company-123' };
+
+      const mockUserCompany = [
+        {
+          id: 'user-company-123',
+          name: 'User Company',
+          description: 'User Company Description',
+          isActive: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      mockCompanyService.getAllCompanies.mockResolvedValue(mockUserCompany);
+
+      await companyController.getAllCompanies(req as Request, res as Response);
+
+      expect(mockCompanyService.getAllCompanies).toHaveBeenCalledWith({
+        companyId: 'user-company-123',
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(mockUserCompany);
+    });
+
+    it('should call service with companyFilter for manager', async () => {
+      // Manager user
+      req.user = {
+        userId: 'manager-1',
+        companyId: 'manager-company-456',
+        roleId: 'role-manager',
+        roleName: 'MANAGER',
+        permissions: ['company:read', 'user:manage'],
+        isSystemAdmin: false,
+      } as TokenPayload;
+
+      // companyFilter set by middleware
+      req.companyFilter = { companyId: 'manager-company-456' };
+
+      const mockManagerCompany = [
+        {
+          id: 'manager-company-456',
+          name: 'Manager Company',
+          description: 'Manager Company Description',
+          isActive: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      mockCompanyService.getAllCompanies.mockResolvedValue(mockManagerCompany);
+
+      await companyController.getAllCompanies(req as Request, res as Response);
+
+      expect(mockCompanyService.getAllCompanies).toHaveBeenCalledWith({
+        companyId: 'manager-company-456',
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(mockManagerCompany);
+    });
+  });
+
+  describe('Filtering behavior demonstration', () => {
+    it('should demonstrate the complete filtering flow', async () => {
+      // Simuler le comportement complet du middleware + contrôleur
+
+      // Cas 1: System Admin - Pas de filtrage
+      const adminRequest = {
+        user: {
+          userId: 'admin-1',
+          companyId: 'admin-company',
+          roleName: 'ADMIN',
+          isSystemAdmin: true,
+        } as TokenPayload,
+        companyFilter: undefined, // Pas de filtrage pour les admins
+      } as Request;
+
+      const allCompanies = [
+        {
+          id: 'company-1',
+          name: 'Company 1',
+          description: 'Description 1',
+          isActive: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'company-2',
+          name: 'Company 2',
+          description: 'Description 2',
+          isActive: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'company-3',
+          name: 'Company 3',
+          description: 'Description 3',
+          isActive: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      mockCompanyService.getAllCompanies.mockResolvedValueOnce(allCompanies);
+
+      await companyController.getAllCompanies(adminRequest, res as Response);
+
+      expect(mockCompanyService.getAllCompanies).toHaveBeenCalledWith(
+        undefined
+      );
+      expect(res.json).toHaveBeenCalledWith(allCompanies);
+
+      // Reset mocks
+      jest.clearAllMocks();
+
+      // Cas 2: Utilisateur normal - Filtrage par entreprise
+      const userRequest = {
+        user: {
+          userId: 'user-1',
+          companyId: 'company-2',
+          roleName: 'USER',
+          isSystemAdmin: false,
+        } as TokenPayload,
+        companyFilter: { companyId: 'company-2' }, // Filtrage par middleware
+      } as Request;
+
+      const userCompany = [
+        {
+          id: 'company-2',
+          name: 'Company 2',
+          description: 'Description 2',
+          isActive: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      mockCompanyService.getAllCompanies.mockResolvedValueOnce(userCompany);
+
+      await companyController.getAllCompanies(userRequest, res as Response);
+
+      expect(mockCompanyService.getAllCompanies).toHaveBeenCalledWith({
+        companyId: 'company-2',
+      });
+      expect(res.json).toHaveBeenCalledWith(userCompany);
+    });
+  });
+});

--- a/tests/unit/companyService.filtering.test.ts
+++ b/tests/unit/companyService.filtering.test.ts
@@ -1,0 +1,209 @@
+import { CompanyService } from '../../src/services/company/companyService';
+import { ICompanyRepository } from '../../src/repositories/company/ICompanyRepository';
+import { Company } from '../../src/generated/prisma';
+
+describe('CompanyService - Filtering', () => {
+  let companyService: CompanyService;
+  let mockCompanyRepository: jest.Mocked<ICompanyRepository>;
+
+  beforeEach(() => {
+    mockCompanyRepository = {
+      create: jest.fn(),
+      getCompanyById: jest.fn(),
+      getCompanyByName: jest.fn(),
+      getAllCompanies: jest.fn(),
+      updateCompany: jest.fn(),
+      deleteCompany: jest.fn(),
+      getCompaniesByUser: jest.fn(),
+      canUserAccessCompany: jest.fn(),
+    } as Partial<
+      jest.Mocked<ICompanyRepository>
+    > as jest.Mocked<ICompanyRepository>;
+
+    companyService = new CompanyService(mockCompanyRepository);
+  });
+
+  describe('getAllCompanies with filtering', () => {
+    const mockCompanies: Company[] = [
+      {
+        id: 'company-1',
+        name: 'Company 1',
+        description: 'Description 1',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 'company-2',
+        name: 'Company 2',
+        description: 'Description 2',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    it('should return all companies when no filter is provided (System Admin)', async () => {
+      mockCompanyRepository.getAllCompanies.mockResolvedValue(mockCompanies);
+
+      const result = await companyService.getAllCompanies();
+
+      expect(mockCompanyRepository.getAllCompanies).toHaveBeenCalledWith(
+        undefined
+      );
+      expect(result).toEqual(mockCompanies);
+    });
+
+    it('should return filtered companies when companyFilter is provided', async () => {
+      const filteredCompany = [mockCompanies[0]];
+      const filter = { companyId: 'company-1' };
+
+      mockCompanyRepository.getAllCompanies.mockResolvedValue(filteredCompany);
+
+      const result = await companyService.getAllCompanies(filter);
+
+      expect(mockCompanyRepository.getAllCompanies).toHaveBeenCalledWith(
+        filter
+      );
+      expect(result).toEqual(filteredCompany);
+    });
+
+    it('should return empty array when filtered company does not exist', async () => {
+      const filter = { companyId: 'non-existent-company' };
+
+      mockCompanyRepository.getAllCompanies.mockResolvedValue([]);
+
+      const result = await companyService.getAllCompanies(filter);
+
+      expect(mockCompanyRepository.getAllCompanies).toHaveBeenCalledWith(
+        filter
+      );
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getCompaniesByUser', () => {
+    const mockUserCompany: Company = {
+      id: 'user-company-1',
+      name: 'User Company',
+      description: 'User Company Description',
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const mockAllCompanies: Company[] = [
+      mockUserCompany,
+      {
+        id: 'other-company-1',
+        name: 'Other Company',
+        description: 'Other Company Description',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    it('should return all companies for System Admin', async () => {
+      mockCompanyRepository.getCompaniesByUser.mockResolvedValue(
+        mockAllCompanies
+      );
+
+      const result = await companyService.getCompaniesByUser(
+        'admin-user-id',
+        true
+      );
+
+      expect(mockCompanyRepository.getCompaniesByUser).toHaveBeenCalledWith(
+        'admin-user-id',
+        true
+      );
+      expect(result).toEqual(mockAllCompanies);
+    });
+
+    it('should return only user company for normal user', async () => {
+      mockCompanyRepository.getCompaniesByUser.mockResolvedValue([
+        mockUserCompany,
+      ]);
+
+      const result = await companyService.getCompaniesByUser(
+        'normal-user-id',
+        false
+      );
+
+      expect(mockCompanyRepository.getCompaniesByUser).toHaveBeenCalledWith(
+        'normal-user-id',
+        false
+      );
+      expect(result).toEqual([mockUserCompany]);
+    });
+
+    it('should return empty array if user has no company', async () => {
+      mockCompanyRepository.getCompaniesByUser.mockResolvedValue([]);
+
+      const result = await companyService.getCompaniesByUser(
+        'orphan-user-id',
+        false
+      );
+
+      expect(mockCompanyRepository.getCompaniesByUser).toHaveBeenCalledWith(
+        'orphan-user-id',
+        false
+      );
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('canUserAccessCompany', () => {
+    it('should return true for System Admin accessing any company', async () => {
+      mockCompanyRepository.canUserAccessCompany.mockResolvedValue(true);
+
+      const result = await companyService.canUserAccessCompany(
+        'any-company-id',
+        'admin-user-id',
+        true
+      );
+
+      expect(mockCompanyRepository.canUserAccessCompany).toHaveBeenCalledWith(
+        'any-company-id',
+        'admin-user-id',
+        true
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should return true for user accessing their own company', async () => {
+      mockCompanyRepository.canUserAccessCompany.mockResolvedValue(true);
+
+      const result = await companyService.canUserAccessCompany(
+        'user-company-id',
+        'user-id',
+        false
+      );
+
+      expect(mockCompanyRepository.canUserAccessCompany).toHaveBeenCalledWith(
+        'user-company-id',
+        'user-id',
+        false
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should return false for user accessing other company', async () => {
+      mockCompanyRepository.canUserAccessCompany.mockResolvedValue(false);
+
+      const result = await companyService.canUserAccessCompany(
+        'other-company-id',
+        'user-id',
+        false
+      );
+
+      expect(mockCompanyRepository.canUserAccessCompany).toHaveBeenCalledWith(
+        'other-company-id',
+        'user-id',
+        false
+      );
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/tests/unit/companyService.test.ts
+++ b/tests/unit/companyService.test.ts
@@ -15,6 +15,8 @@ const mockCompanyRepository: jest.Mocked<ICompanyRepository> = {
   getAllCompanies: jest.fn(),
   updateCompany: jest.fn(),
   deleteCompany: jest.fn(),
+  getCompaniesByUser: jest.fn(),
+  canUserAccessCompany: jest.fn(),
 };
 
 describe('CompanyService', () => {
@@ -233,7 +235,9 @@ describe('CompanyService', () => {
 
       const result = await companyService.getAllCompanies();
 
-      expect(mockCompanyRepository.getAllCompanies).toHaveBeenCalledWith();
+      expect(mockCompanyRepository.getAllCompanies).toHaveBeenCalledWith(
+        undefined
+      );
       expect(result).toEqual(companies);
     });
 
@@ -242,7 +246,9 @@ describe('CompanyService', () => {
 
       const result = await companyService.getAllCompanies();
 
-      expect(mockCompanyRepository.getAllCompanies).toHaveBeenCalledWith();
+      expect(mockCompanyRepository.getAllCompanies).toHaveBeenCalledWith(
+        undefined
+      );
       expect(result).toEqual([]);
     });
 
@@ -251,7 +257,9 @@ describe('CompanyService', () => {
       mockCompanyRepository.getAllCompanies.mockRejectedValue(error);
 
       await expect(companyService.getAllCompanies()).rejects.toThrow(error);
-      expect(mockCompanyRepository.getAllCompanies).toHaveBeenCalledWith();
+      expect(mockCompanyRepository.getAllCompanies).toHaveBeenCalledWith(
+        undefined
+      );
     });
   });
 


### PR DESCRIPTION
- Extend ICompanyRepository interface with filtering methods
- Add getAllCompanies(filter) method with optional companyId filtering
- Add getCompaniesByUser() method for user-based company access
- Add canUserAccessCompany() method for access validation
- Update CompanyService to implement new filtering methods
- Update CompanyController to use req.companyFilter from middleware
- Complete test coverage for filtering functionality (13 tests)
- Integration tests demonstrating complete filtering flow

B2B Filtering Logic:
- System Admins: access all companies (no filtering)
- Regular users: access only their company (automatic filtering)
- Repository-level filtering implementation for data isolation