### PR TITLE
:sparkles: Add company endpoints to OpenAPI specification

### DIFF
--- a/src/swagger/openapi.yaml
+++ b/src/swagger/openapi.yaml
@@ -1,3 +1,4 @@
+---
 openapi: 3.0.0
 info:
   title: Factory Backend API
@@ -7,6 +8,290 @@ servers:
     description: Development server
 
 paths:
+  /api/v1/company:
+    post:
+      tags:
+        - Company
+      summary: Create a new company
+      description: |
+        Creates a new company.
+        Requires appropriate administrative permissions.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCompanyRequest'
+      responses:
+        '201':
+          description: Company created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompanyResponse'
+        '400':
+          description: Invalid request data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthErrorResponse'
+        '403':
+          description: Insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    get:
+      tags:
+        - Company
+      summary: Get companies
+      description: |
+        Retrieves companies based on user permissions.
+        Access restrictions apply based on user role.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Companies retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompanyListResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthErrorResponse'
+        '403':
+          description: Insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/company/current:
+    get:
+      tags:
+        - Company
+      summary: Get current user's company
+      description: |
+        Retrieves the company associated with the current user.
+        Requires appropriate access permissions.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Company retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompanyResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthErrorResponse'
+        '403':
+          description: Insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Company not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/company/{id}:
+    get:
+      tags:
+        - Company
+      summary: Get company by ID
+      description: |
+        Retrieves a specific company by its ID.
+        Requires appropriate access permissions.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Company ID
+      responses:
+        '200':
+          description: Company retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompanyResponse'
+        '401':
+          description: Authentication required
+          content:
+            journalication/json:
+              schema:
+                $ref: '#/components/schemas/AuthErrorResponse'
+        '403':
+          description: Insufficient permissions or access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Company not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    put:
+      tags:
+        - Company
+      summary: Update a company
+      description: |
+        Updates an existing company.
+        Requires appropriate administrative permissions.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Company ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCompanyRequest'
+      responses:
+        '200':
+          description: Company updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompanyResponse'
+        '400':
+          description: Invalid request data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthErrorResponse'
+        '403':
+          description: Insufficient permissions or access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Company not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    delete:
+      tags:
+        - Company
+      summary: Delete a company
+      description: |
+        Deletes a company.
+        Requires appropriate administrative permissions.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Company ID
+      responses:
+        '200':
+          description: Company deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: 'Company deleted successfully'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthErrorResponse'
+        '403':
+          description: Insufficient permissions or access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Company not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /api/v1/auth/login:
     post:
       tags:
@@ -38,7 +323,8 @@ paths:
       summary: User logout
       description: |
         Logs out the user by invalidating the token and session.
-        Requires a valid JWT token in the Authorization header with the format: "Bearer <token>"
+        Requires a valid JWT token in the Authorization header with the format:
+        "Bearer <token>"
       security:
         - bearerAuth: []
       responses:
@@ -151,6 +437,69 @@ components:
           type: string
           nullable: true
           description: User's last name
+
+    CreateCompanyRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Company name
+        description:
+          type: string
+          nullable: true
+          description: Company description
+        isActive:
+          type: boolean
+          default: true
+          description: Whether the company is active
+
+    UpdateCompanyRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Company name
+        description:
+          type: string
+          nullable: true
+          description: Company description
+        isActive:
+          type: boolean
+          description: Whether the company is active
+
+    CompanyResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the company
+        name:
+          type: string
+          description: Company name
+        description:
+          type: string
+          nullable: true
+          description: Company description
+        isActive:
+          type: boolean
+          description: Whether the company is active
+        createdAt:
+          type: string
+          format: date-time
+          description: Creation timestamp
+        updatedAt:
+          type: string
+          format: date-time
+          description: Last update timestamp
+
+    CompanyListResponse:
+      type: array
+      items:
+        $ref: '#/components/schemas/CompanyResponse'
 
   securitySchemes:
     bearerAuth:


### PR DESCRIPTION
Add comprehensive OpenAPI documentation for company-related endpoints including:
- POST /api/v1/company - Create new company (requires company:create permission)
- GET /api/v1/company - Get all companies with role-based access control
- GET /api/v1/company/current - Get current user's company
- GET /api/v1/company/{id} - Get specific company by ID