### PR TITLE
:wrench: Implement graceful logout handling

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -51,7 +51,7 @@ export class AuthController extends BaseController {
       return this.handleError(res, error, (err: unknown) => {
         const authError = err as Error;
         if (authError.message === 'Invalid token') {
-          return { statusCode: 401, message: 'Invalid token' };
+          return { statusCode: 200, message: 'Logout successful' };
         }
         return { statusCode: 500, message: authError.message };
       });

--- a/src/services/auth/tokenService.ts
+++ b/src/services/auth/tokenService.ts
@@ -76,7 +76,7 @@ export class TokenService implements ITokenService {
     });
 
     if (!existingSession) {
-      throw new Error('Invalid token');
+      return;
     }
 
     await this.prisma.session.update({

--- a/src/utils/tokenUtils.ts
+++ b/src/utils/tokenUtils.ts
@@ -12,10 +12,10 @@ export function extractToken(authHeader?: string): string | null {
 export async function verifySession(token: string) {
   const prisma = container.resolve<IPrismaService>('IPrismaService');
   const session = await prisma.session.findUnique({
-    where: { token, isActive: true },
+    where: { token },
   });
 
-  if (!session || new Date() > session.expiresAt) {
+  if (!session || !session.isActive || new Date() > session.expiresAt) {
     throw new Error('Session expired or invalid');
   }
 

--- a/tests/controllers/authController.test.ts
+++ b/tests/controllers/authController.test.ts
@@ -109,15 +109,15 @@ describe('AuthController', () => {
       expect(res.body).toEqual({ message: 'Missing token' });
     });
 
-    it('should return 401 if token is invalid', async () => {
+    it('should return 200 even if token is invalid (graceful logout)', async () => {
       mockLogout.mockRejectedValue(new Error('Invalid token'));
 
       const res = await request(app)
         .post('/logout')
         .set('Authorization', 'Bearer invalid');
 
-      expect(res.status).toBe(401);
-      expect(res.body).toEqual({ message: 'Invalid token' });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ message: 'Logout successful' });
     });
 
     it('should return 500 for unexpected errors', async () => {

--- a/tests/integration/authLogout.integration.test.ts
+++ b/tests/integration/authLogout.integration.test.ts
@@ -1,0 +1,193 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import { container } from 'tsyringe';
+import { AuthController } from '../../src/controllers/authController';
+import { AuthService } from '../../src/services/auth/authService';
+import { TokenService } from '../../src/services/auth/tokenService';
+import { IPrismaService } from '../../src/database/interfaces';
+import { Session } from '../../src/generated/prisma';
+
+const mockLogin = jest.fn();
+const mockLogout = jest.fn();
+const mockGenerateToken = jest.fn();
+const mockVerifyToken = jest.fn();
+const mockInvalidateToken = jest.fn();
+
+const mockAuthService = {
+  login: mockLogin,
+  logout: mockLogout,
+} as unknown as AuthService;
+
+const mockTokenService = {
+  generateToken: mockGenerateToken,
+  verifyToken: mockVerifyToken,
+  invalidateToken: mockInvalidateToken,
+} as unknown as TokenService;
+
+const mockFindUniqueSession = jest.fn();
+const mockUpdateSession = jest.fn();
+const mockCreateSession = jest.fn();
+
+const mockPrismaService = {
+  session: {
+    findUnique: mockFindUniqueSession,
+    update: mockUpdateSession,
+    create: mockCreateSession,
+  },
+} as unknown as IPrismaService;
+
+jest.mock('tsyringe', () => ({
+  ...jest.requireActual('tsyringe'),
+  container: {
+    resolve: jest.fn(),
+  },
+}));
+
+describe('Auth Logout Integration', () => {
+  let app: express.Application;
+  let authController: AuthController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (container.resolve as jest.Mock).mockImplementation((token: unknown) => {
+      if (token === AuthService) return mockAuthService;
+      if (token === TokenService) return mockTokenService;
+      if (token === 'IPrismaService') return mockPrismaService;
+      return null;
+    });
+
+    authController = new AuthController(mockAuthService);
+    app = express();
+    app.use(express.json());
+    app.post('/login', (req: Request, res: Response) =>
+      authController.login(req, res)
+    );
+    app.post('/logout', (req: Request, res: Response) =>
+      authController.logout(req, res)
+    );
+  });
+
+  describe('Complete Login -> Logout flow', () => {
+    it('should successfully login and then logout', async () => {
+      const mockToken = 'valid-jwt-token';
+      const mockUser = {
+        id: 'user-123',
+        email: 'test@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+      };
+
+      mockLogin.mockResolvedValue({ token: mockToken, user: mockUser });
+
+      const loginResponse = await request(app)
+        .post('/login')
+        .send({ email: 'test@example.com', password: 'password123' });
+
+      expect(loginResponse.status).toBe(200);
+      expect(loginResponse.body).toEqual({
+        message: 'Login successful',
+        token: mockToken,
+        user: mockUser,
+      });
+
+      mockLogout.mockResolvedValue(undefined);
+
+      const logoutResponse = await request(app)
+        .post('/logout')
+        .set('Authorization', `Bearer ${mockToken}`);
+
+      expect(logoutResponse.status).toBe(200);
+      expect(logoutResponse.body).toEqual({ message: 'Logout successful' });
+      expect(mockLogout).toHaveBeenCalledWith(mockToken);
+    });
+
+    it('should handle logout with non-existent token gracefully', async () => {
+      const nonExistentToken = 'non-existent-token';
+
+      // Mock to simulate a token that does not exist in the database
+      mockLogout.mockResolvedValue(undefined);
+
+      const response = await request(app)
+        .post('/logout')
+        .set('Authorization', `Bearer ${nonExistentToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ message: 'Logout successful' });
+    });
+
+    it('should return 400 when Authorization header is missing', async () => {
+      const response = await request(app).post('/logout');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ message: 'Missing token' });
+    });
+
+    it('should return 400 when Authorization header is malformed', async () => {
+      const response = await request(app)
+        .post('/logout')
+        .set('Authorization', 'InvalidFormat');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ message: 'Missing token' });
+    });
+
+    it('should handle server errors during logout', async () => {
+      const validToken = 'valid-token';
+
+      mockLogout.mockRejectedValue(new Error('Database connection failed'));
+
+      const response = await request(app)
+        .post('/logout')
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({ message: 'Database connection failed' });
+    });
+  });
+
+  describe('Token Service Integration', () => {
+    it('should invalidate token successfully', async () => {
+      const token = 'test-token';
+      const mockSession: Partial<Session> = {
+        token,
+        isActive: true,
+        expiresAt: new Date(Date.now() + 3600000),
+      };
+
+      mockFindUniqueSession.mockResolvedValue(mockSession);
+      mockUpdateSession.mockResolvedValue({ ...mockSession, isActive: false });
+
+      const jwtMock = { sign: jest.fn(), verify: jest.fn() };
+      const tokenService = new TokenService(
+        mockPrismaService,
+        jwtMock as unknown as typeof import('jsonwebtoken')
+      );
+
+      await tokenService.invalidateToken(token);
+
+      expect(mockFindUniqueSession).toHaveBeenCalledWith({ where: { token } });
+      expect(mockUpdateSession).toHaveBeenCalledWith({
+        where: { token },
+        data: { isActive: false },
+      });
+    });
+
+    it('should handle non-existent token gracefully in invalidateToken', async () => {
+      const token = 'non-existent-token';
+
+      mockFindUniqueSession.mockResolvedValue(null);
+
+      const jwtMock = { sign: jest.fn(), verify: jest.fn() };
+      const tokenService = new TokenService(
+        mockPrismaService,
+        jwtMock as unknown as typeof import('jsonwebtoken')
+      );
+
+      await expect(tokenService.invalidateToken(token)).resolves.not.toThrow();
+
+      expect(mockFindUniqueSession).toHaveBeenCalledWith({ where: { token } });
+      expect(mockUpdateSession).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/tokenService.test.ts
+++ b/tests/unit/tokenService.test.ts
@@ -1,4 +1,4 @@
-// ✅ Mock JWT avant tout import
+// Mock JWT before any import
 jest.mock('jsonwebtoken', () => ({
   sign: jest.fn(),
   verify: jest.fn(),
@@ -22,7 +22,6 @@ const mockPrismaService = {
   },
 };
 
-// Cast pour Jest uniquement là où nécessaire
 const mockFindUnique = mockPrismaService.session.findUnique as jest.Mock<
   Promise<Session | null>,
   [Prisma.SessionFindUniqueArgs]
@@ -204,12 +203,12 @@ describe('TokenService', () => {
       });
     });
 
-    it('should throw if session not found', async () => {
+    it('should not throw if session not found (graceful invalidation)', async () => {
       mockFindUnique.mockResolvedValue(null);
 
-      await expect(tokenService.invalidateToken('unknown')).rejects.toThrow(
-        'Invalid token'
-      );
+      await expect(
+        tokenService.invalidateToken('unknown')
+      ).resolves.not.toThrow();
 
       expect(mockUpdate).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
Change logout behavior to return 200 status even for invalid tokens, making logout operations more user-friendly. Previously invalid tokens would return 401 errors, but now the system handles them gracefully by treating them as successful logout operations.

- Modified authController to return 200 with success message for invalid tokens
- Updated tokenService to return early instead of throwing errors for non-existent sessions
- Enhanced tokenUtils to check both session existence and active status
- Added integration tests to verify graceful logout behavior
- Updated existing unit tests to reflect new logout response expectations

This change improves user experience by ensuring logout operations always succeed from the client perspective, even when tokens are expired or invalid.