### PR TITLE
:wrench: Add API response transformation for processed items

### DIFF
--- a/src/controllers/packingListController.ts
+++ b/src/controllers/packingListController.ts
@@ -7,6 +7,21 @@ import {
 import { inject, injectable } from 'tsyringe';
 import { IPackingListService } from '../services/packingList/interfaces';
 import { BaseController } from './baseController';
+import { ProcessedItem, ProcessedItemResponse } from '../types';
+
+function transformProcessedItemForAPI(
+  item: ProcessedItem
+): ProcessedItemResponse {
+  return {
+    Description: item.description,
+    Category: item.category,
+    COO: item.coo,
+    Ctns: item.ctns,
+    'Qty Per Box': item.qty,
+    'Total Qty': item.totalQty,
+    Pal: item.pal,
+  };
+}
 
 @injectable()
 export class PackingListController extends BaseController {
@@ -63,7 +78,7 @@ export class PackingListController extends BaseController {
 
       return res.status(200).json({
         success: true,
-        data: processResult.data.data,
+        data: processResult.data.data.map(transformProcessedItemForAPI),
         summary: {
           totalRows: cleanedData.length,
           processedRows: processResult.data.summary.processedRows,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,16 @@ export interface ProcessedItem {
   pal?: number;
 }
 
+export interface ProcessedItemResponse {
+  Description: string;
+  Category: string;
+  COO?: string;
+  Ctns: number;
+  'Qty Per Box': number;
+  'Total Qty': number;
+  Pal?: number;
+}
+
 export interface ProcessingSummary {
   processedRows: number;
   totalPcs: number;

--- a/tests/controllers/packingListController.test.ts
+++ b/tests/controllers/packingListController.test.ts
@@ -26,7 +26,7 @@ describe('PackingListController', () => {
   it('should return 200 with processed data when input is valid', async () => {
     const fixture = generateValidPackingList(2);
 
-    const processed = fixture.map(item => ({
+    const internalProcessed = fixture.map(item => ({
       ctns: Number(item.CTN),
       qty: item.QTY,
       totalQty: item.QTY,
@@ -34,10 +34,20 @@ describe('PackingListController', () => {
       description: item['DESCRIPTION MIN'],
     }));
 
+    const apiResponseProcessed = internalProcessed.map(item => ({
+      Ctns: item.ctns,
+      'Qty Per Box': item.qty,
+      'Total Qty': item.totalQty,
+      Category: item.category,
+      Description: item.description,
+      COO: undefined,
+      Pal: undefined,
+    }));
+
     const req: Partial<Request> = { body: fixture };
 
     const result: ProcessingResult = {
-      data: processed,
+      data: internalProcessed,
       summary: {
         processedRows: fixture.length,
         totalPcs: fixture.reduce((acc, item) => acc + item.QTY, 0),
@@ -51,7 +61,7 @@ describe('PackingListController', () => {
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({
       success: true,
-      data: processed,
+      data: apiResponseProcessed,
       summary: {
         totalRows: expect.any(Number),
         processedRows: fixture.length,


### PR DESCRIPTION
Add ProcessedItemResponse type and transformProcessedItemForAPI function to format internal processed item data for API responses. This ensures consistent field naming (PascalCase) and structure in API outputs while keeping internal data structures unchanged. Update controller to use the transformation function and modify tests to verify correct API response format.