### PR TITLE
:sparkles: Add Number of Ctns field to packing list output

### DIFF
--- a/src/controllers/packingListController.ts
+++ b/src/controllers/packingListController.ts
@@ -20,6 +20,7 @@ function transformProcessedItemForAPI(
     'Qty Per Box': item.qty,
     'Total Qty': item.totalQty,
     Pal: item.pal,
+    'Number of Ctns': item.numberOfCtns || '1',
   };
 }
 

--- a/src/services/packingList/packingListService.ts
+++ b/src/services/packingList/packingListService.ts
@@ -9,6 +9,7 @@ import {
 } from '../../types';
 import { extractCtnBlocksFromRow } from '../../utils/extractCtnBlocksFromRow';
 import { sortPackingListItems } from '../../utils/sortPackingListItems';
+import { calculateNumberOfCtns } from '../../utils/calculateNumberOfCtns';
 
 import { IPackingListService } from './interfaces';
 
@@ -72,10 +73,13 @@ export class PackingListService implements IPackingListService {
       // Sorting the results using the utility function
       const sortedResult = sortPackingListItems(result);
 
+      // Calculate "Number of Ctns" values
+      const resultWithNumberOfCtns = calculateNumberOfCtns(sortedResult);
+
       return createSuccess({
-        data: sortedResult,
+        data: resultWithNumberOfCtns,
         summary: {
-          processedRows: sortedResult.length,
+          processedRows: resultWithNumberOfCtns.length,
           totalPcs,
         },
       });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export interface ProcessedItem {
   qty: number;
   totalQty: number;
   pal?: number;
+  numberOfCtns?: string;
 }
 
 export interface ProcessedItemResponse {
@@ -32,6 +33,7 @@ export interface ProcessedItemResponse {
   'Qty Per Box': number;
   'Total Qty': number;
   Pal?: number;
+  'Number of Ctns': string;
 }
 
 export interface ProcessingSummary {

--- a/src/utils/calculateNumberOfCtns.ts
+++ b/src/utils/calculateNumberOfCtns.ts
@@ -1,0 +1,25 @@
+import { ProcessedItem } from '../types';
+
+/**
+ * Calculates the "Number of Ctns" value for each item based on the logic:
+ * - "1" for the first occurrence of a carton number
+ * - "*" for subsequent occurrences of the same carton
+ *
+ * @param items - Array of ProcessedItem to process
+ * @returns Array of items with the numberOfCtns field added
+ */
+export function calculateNumberOfCtns(items: ProcessedItem[]): ProcessedItem[] {
+  // Sort by ascending carton number
+  const sortedItems = [...items].sort((a, b) => a.ctns - b.ctns);
+
+  let currentCTN: number | null = null;
+
+  return sortedItems.map(item => {
+    if (item.ctns !== currentCTN) {
+      currentCTN = item.ctns;
+      return { ...item, numberOfCtns: '1' };
+    } else {
+      return { ...item, numberOfCtns: '*' };
+    }
+  });
+}

--- a/tests/controllers/packingListController.test.ts
+++ b/tests/controllers/packingListController.test.ts
@@ -42,6 +42,7 @@ describe('PackingListController', () => {
       Description: item.description,
       COO: undefined,
       Pal: undefined,
+      'Number of Ctns': '1',
     }));
 
     const req: Partial<Request> = { body: fixture };

--- a/tests/unit/calculateNumberOfCtns.test.ts
+++ b/tests/unit/calculateNumberOfCtns.test.ts
@@ -1,0 +1,174 @@
+import { calculateNumberOfCtns } from '../../src/utils/calculateNumberOfCtns';
+import { ProcessedItem } from '../../src/types';
+
+describe('calculateNumberOfCtns', () => {
+  it('should assign "1" to first occurrence of each CTN and "*" to subsequent ones', () => {
+    const items: ProcessedItem[] = [
+      {
+        description: 'Produit A',
+        category: 'Category A',
+        ctns: 1,
+        qty: 50,
+        totalQty: 50,
+        pal: 1,
+      },
+      {
+        description: 'Produit B',
+        category: 'Category B',
+        ctns: 1,
+        qty: 30,
+        totalQty: 30,
+        pal: 1,
+      },
+      {
+        description: 'Produit C',
+        category: 'Category C',
+        ctns: 2,
+        qty: 100,
+        totalQty: 100,
+        pal: 2,
+      },
+      {
+        description: 'Produit A',
+        category: 'Category A',
+        ctns: 3,
+        qty: 50,
+        totalQty: 50,
+        pal: 3,
+      },
+      {
+        description: 'Produit D',
+        category: 'Category D',
+        ctns: 3,
+        qty: 20,
+        totalQty: 20,
+        pal: 3,
+      },
+    ];
+
+    const result = calculateNumberOfCtns(items);
+
+    expect(result).toHaveLength(5);
+
+    // CTN 1 - First occurrence
+    expect(result[0].numberOfCtns).toBe('1');
+    expect(result[0].ctns).toBe(1);
+    expect(result[0].description).toBe('Produit A');
+
+    // CTN 1 - Second occurrence
+    expect(result[1].numberOfCtns).toBe('*');
+    expect(result[1].ctns).toBe(1);
+    expect(result[1].description).toBe('Produit B');
+
+    // CTN 2 - First occurrence
+    expect(result[2].numberOfCtns).toBe('1');
+    expect(result[2].ctns).toBe(2);
+    expect(result[2].description).toBe('Produit C');
+
+    // CTN 3 - First occurrence
+    expect(result[3].numberOfCtns).toBe('1');
+    expect(result[3].ctns).toBe(3);
+    expect(result[3].description).toBe('Produit A');
+
+    // CTN 3 - Second occurrence
+    expect(result[4].numberOfCtns).toBe('*');
+    expect(result[4].ctns).toBe(3);
+    expect(result[4].description).toBe('Produit D');
+  });
+
+  it('should handle items already sorted by CTN', () => {
+    const items: ProcessedItem[] = [
+      {
+        description: 'Produit A',
+        category: 'Category A',
+        ctns: 1,
+        qty: 50,
+        totalQty: 50,
+        pal: 1,
+      },
+      {
+        description: 'Produit B',
+        category: 'Category B',
+        ctns: 1,
+        qty: 30,
+        totalQty: 30,
+        pal: 1,
+      },
+    ];
+
+    const result = calculateNumberOfCtns(items);
+
+    expect(result[0].numberOfCtns).toBe('1');
+    expect(result[1].numberOfCtns).toBe('*');
+  });
+
+  it('should handle items not sorted by CTN', () => {
+    const items: ProcessedItem[] = [
+      {
+        description: 'Produit C',
+        category: 'Category C',
+        ctns: 2,
+        qty: 100,
+        totalQty: 100,
+        pal: 2,
+      },
+      {
+        description: 'Produit A',
+        category: 'Category A',
+        ctns: 1,
+        qty: 50,
+        totalQty: 50,
+        pal: 1,
+      },
+      {
+        description: 'Produit B',
+        category: 'Category B',
+        ctns: 1,
+        qty: 30,
+        totalQty: 30,
+        pal: 1,
+      },
+    ];
+
+    const result = calculateNumberOfCtns(items);
+
+    // Should be sorted by CTN first
+    expect(result[0].ctns).toBe(1);
+    expect(result[0].numberOfCtns).toBe('1');
+    expect(result[0].description).toBe('Produit A');
+
+    expect(result[1].ctns).toBe(1);
+    expect(result[1].numberOfCtns).toBe('*');
+    expect(result[1].description).toBe('Produit B');
+
+    expect(result[2].ctns).toBe(2);
+    expect(result[2].numberOfCtns).toBe('1');
+    expect(result[2].description).toBe('Produit C');
+  });
+
+  it('should handle single item', () => {
+    const items: ProcessedItem[] = [
+      {
+        description: 'Produit A',
+        category: 'Category A',
+        ctns: 1,
+        qty: 50,
+        totalQty: 50,
+        pal: 1,
+      },
+    ];
+
+    const result = calculateNumberOfCtns(items);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].numberOfCtns).toBe('1');
+  });
+
+  it('should handle empty array', () => {
+    const items: ProcessedItem[] = [];
+
+    const result = calculateNumberOfCtns(items);
+
+    expect(result).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Add a new 'Number of Ctns' field to the packing list processing pipeline. This field is calculated using a new utility function calculateNumberOfCtns and included in both the internal ProcessedItem type and the API response format. The field defaults to '1' when not provided, ensuring backward compatibility with existing data.