### PR TITLE
:sparkles: Add getRoleByIdWithPermissions to include associated permissions

### DIFF
--- a/src/controllers/roleController.ts
+++ b/src/controllers/roleController.ts
@@ -23,7 +23,7 @@ export class RoleController extends BaseController {
   getRoleById = async (req: Request, res: Response): Promise<Response> => {
     try {
       const { id } = req.params;
-      const role = await this.roleService.getRoleById(id);
+      const role = await this.roleService.getRoleByIdWithPermissions(id);
 
       if (!role) {
         return res.status(404).json({ message: 'Role not found' });

--- a/src/repositories/role/IRoleRepository.ts
+++ b/src/repositories/role/IRoleRepository.ts
@@ -1,4 +1,5 @@
 import { Role, Prisma } from '../../generated/prisma';
+import { RoleWithPermissionsResponse } from '../../types/role';
 
 export interface IRoleRepository {
   create(data: Prisma.RoleCreateInput): Promise<Role>;
@@ -8,6 +9,9 @@ export interface IRoleRepository {
   update(id: string, data: Prisma.RoleUpdateInput): Promise<Role>;
   delete(id: string): Promise<Role>;
 
+  findByIdWithPermissions(
+    id: string
+  ): Promise<RoleWithPermissionsResponse | null>;
   findSystemRoles(): Promise<Role[]>;
   findCustomRolesByCompany(companyId: string): Promise<Role[]>;
   findAllRolesForCompany(companyId: string): Promise<Role[]>;

--- a/src/repositories/role/PrismaRoleRepository.ts
+++ b/src/repositories/role/PrismaRoleRepository.ts
@@ -2,6 +2,7 @@ import { injectable, inject } from 'tsyringe';
 import { Role, Prisma } from '../../generated/prisma';
 import { IRoleRepository } from './IRoleRepository';
 import { IPrismaService } from '../../database/interfaces';
+import { RoleWithPermissionsResponse } from '../../types/role';
 
 @injectable()
 export class PrismaRoleRepository implements IRoleRepository {
@@ -13,6 +14,28 @@ export class PrismaRoleRepository implements IRoleRepository {
 
   async findById(id: string): Promise<Role | null> {
     return this.prisma.role.findUnique({ where: { id } });
+  }
+
+  async findByIdWithPermissions(
+    id: string
+  ): Promise<RoleWithPermissionsResponse | null> {
+    const role = await this.prisma.role.findUnique({
+      where: { id },
+      include: {
+        rolePermissions: {
+          include: {
+            permission: true,
+          },
+        },
+      },
+    });
+
+    if (!role) return null;
+
+    return {
+      ...role,
+      permissions: role.rolePermissions || [],
+    };
   }
 
   async findByName(name: string): Promise<Role | null> {

--- a/src/services/role/interfaces.ts
+++ b/src/services/role/interfaces.ts
@@ -1,9 +1,16 @@
 import { Role } from '../../generated/prisma';
-import { CreateRoleRequest, UpdateRoleRequest } from '../../types/role';
+import {
+  CreateRoleRequest,
+  UpdateRoleRequest,
+  RoleWithPermissionsResponse,
+} from '../../types/role';
 
 export interface IRoleService {
   createRole(data: CreateRoleRequest): Promise<Role>;
   getRoleById(id: string): Promise<Role | null>;
+  getRoleByIdWithPermissions(
+    id: string
+  ): Promise<RoleWithPermissionsResponse | null>;
   getRoleByName(name: string): Promise<Role | null>;
   getAllRoles(): Promise<Role[]>;
   updateRole(id: string, data: UpdateRoleRequest): Promise<Role>;

--- a/src/services/role/roleService.ts
+++ b/src/services/role/roleService.ts
@@ -1,6 +1,10 @@
 import { IRoleService } from './interfaces';
 import { Role } from '../../generated/prisma';
-import { CreateRoleRequest, UpdateRoleRequest } from '../../types/role';
+import {
+  CreateRoleRequest,
+  UpdateRoleRequest,
+  RoleWithPermissionsResponse,
+} from '../../types/role';
 import { injectable, inject } from 'tsyringe';
 import { IRoleRepository } from '../../repositories/role/IRoleRepository';
 import { ForbiddenError } from '../../errors/customErrors';
@@ -19,6 +23,12 @@ export class RoleService implements IRoleService {
 
   async getRoleById(id: string): Promise<Role | null> {
     return this.roleRepository.findById(id);
+  }
+
+  async getRoleByIdWithPermissions(
+    id: string
+  ): Promise<RoleWithPermissionsResponse | null> {
+    return this.roleRepository.findByIdWithPermissions(id);
   }
 
   async getRoleByName(name: string): Promise<Role | null> {

--- a/src/types/role.ts
+++ b/src/types/role.ts
@@ -15,3 +15,23 @@ export interface UpdateRoleRequest {
   name?: string;
   description?: string;
 }
+
+export interface RoleWithPermissionsResponse {
+  id: string;
+  name: string;
+  description: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  permissions: Array<{
+    id: string;
+    roleId: string;
+    permissionId: string;
+    createdAt: Date;
+    updatedAt: Date;
+    permission: {
+      id: string;
+      name: string;
+      description: string | null;
+    };
+  }>;
+}

--- a/tests/controllers/roleController.test.ts
+++ b/tests/controllers/roleController.test.ts
@@ -16,6 +16,7 @@ jest.mock('../../src/schemas/roleSchema', () => ({
 const mockRoleService = {
   createRole: jest.fn(),
   getRoleById: jest.fn(),
+  getRoleByIdWithPermissions: jest.fn(),
   getRoleByName: jest.fn(),
   getAllRoles: jest.fn(),
   updateRole: jest.fn(),
@@ -108,21 +109,43 @@ describe('RoleController', () => {
   });
 
   describe('getRoleById', () => {
-    it('should return role and status 200 when found', async () => {
-      const role = { id: '1', name: 'ADMIN' };
+    it('should return role with permissions and status 200 when found', async () => {
+      const role = {
+        id: '1',
+        name: 'ADMIN',
+        description: 'Administrator role',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        permissions: [
+          {
+            id: 'perm-1',
+            roleId: '1',
+            permissionId: 'p1',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            permission: {
+              id: 'p1',
+              name: 'admin:read',
+              description: 'Can read admin data',
+            },
+          },
+        ],
+      };
       mockRequest.params = { id: '1' };
-      mockRoleService.getRoleById.mockResolvedValue(role);
+      mockRoleService.getRoleByIdWithPermissions.mockResolvedValue(role);
 
       await controller.getRoleById(mockRequest, mockResponse);
 
-      expect(mockRoleService.getRoleById).toHaveBeenCalledWith('1');
+      expect(mockRoleService.getRoleByIdWithPermissions).toHaveBeenCalledWith(
+        '1'
+      );
       expect(mockResponse.status).toHaveBeenCalledWith(200);
       expect(mockResponse.json).toHaveBeenCalledWith(role);
     });
 
     it('should return 404 when role not found', async () => {
       mockRequest.params = { id: '999' };
-      mockRoleService.getRoleById.mockResolvedValue(null);
+      mockRoleService.getRoleByIdWithPermissions.mockResolvedValue(null);
 
       await controller.getRoleById(mockRequest, mockResponse);
 
@@ -134,7 +157,7 @@ describe('RoleController', () => {
 
     it('should call handleError on exception', async () => {
       const internal = new Error('Database error');
-      mockRoleService.getRoleById.mockRejectedValue(internal);
+      mockRoleService.getRoleByIdWithPermissions.mockRejectedValue(internal);
 
       const spy = jest.spyOn(controller, 'handleError' as keyof RoleController);
       await controller.getRoleById(mockRequest, mockResponse);

--- a/tests/middlewares/roleAccess.test.ts
+++ b/tests/middlewares/roleAccess.test.ts
@@ -14,6 +14,7 @@ import { ForbiddenError } from '../../src/errors/customErrors';
 const mockRoleRepository: jest.Mocked<IRoleRepository> = {
   create: jest.fn(),
   findById: jest.fn(),
+  findByIdWithPermissions: jest.fn(),
   findByName: jest.fn(),
   findAll: jest.fn(),
   update: jest.fn(),

--- a/tests/unit/roleService.test.ts
+++ b/tests/unit/roleService.test.ts
@@ -11,6 +11,7 @@ describe('RoleService', () => {
     mockRoleRepository = {
       create: jest.fn(),
       findById: jest.fn(),
+      findByIdWithPermissions: jest.fn(),
       findByName: jest.fn(),
       findAll: jest.fn(),
       update: jest.fn(),
@@ -159,6 +160,51 @@ describe('RoleService', () => {
         name: 'SuperAdmin',
       });
       expect(result).toEqual(updatedRole);
+    });
+  });
+
+  describe('getRoleByIdWithPermissions', () => {
+    it('should return a role with permissions by ID', async () => {
+      const mockRole = {
+        id: '1',
+        name: 'Admin',
+        description: 'Administrator',
+        createdAt: now,
+        updatedAt: now,
+        permissions: [
+          {
+            id: 'perm-1',
+            roleId: '1',
+            permissionId: 'p1',
+            createdAt: now,
+            updatedAt: now,
+            permission: {
+              id: 'p1',
+              name: 'admin:read',
+              description: 'Can read admin data',
+            },
+          },
+        ],
+      };
+      mockRoleRepository.findByIdWithPermissions.mockResolvedValue(mockRole);
+
+      const result = await roleService.getRoleByIdWithPermissions('1');
+
+      expect(mockRoleRepository.findByIdWithPermissions).toHaveBeenCalledWith(
+        '1'
+      );
+      expect(result).toEqual(mockRole);
+    });
+
+    it('should return null if role is not found by ID', async () => {
+      mockRoleRepository.findByIdWithPermissions.mockResolvedValue(null);
+
+      const result = await roleService.getRoleByIdWithPermissions('99');
+
+      expect(mockRoleRepository.findByIdWithPermissions).toHaveBeenCalledWith(
+        '99'
+      );
+      expect(result).toBeNull();
     });
   });
 


### PR DESCRIPTION

- Introduced RoleWithPermissionsResponse type for structured response
- Updated IRoleRepository with findByIdWithPermissions method
- Implemented PrismaRoleRepository method to fetch role and include rolePermissions
- Added getRoleByIdWithPermissions to IRoleService and RoleService
- Modified RoleController to use new method for role retrieval with permissions to provide complete role data for clients requiring permission details