### PR TITLE
:sparkles: Add endpoint to retrieve company domains by company ID

### DIFF
--- a/src/controllers/domainController.ts
+++ b/src/controllers/domainController.ts
@@ -89,4 +89,18 @@ export class DomainController extends BaseController {
       return this.handleError(res, error, mapDomainError);
     }
   };
+
+  getCompanyDomainsByCompanyId = async (
+    req: Request,
+    res: Response
+  ): Promise<Response> => {
+    try {
+      const { companyId } = req.params;
+      const companyDomains =
+        await this.domainService.getCompanyDomainsByCompanyId(companyId);
+      return res.status(200).json(companyDomains);
+    } catch (error) {
+      return this.handleError(res, error, mapDomainError);
+    }
+  };
 }

--- a/src/routes/api/v1/domain.ts
+++ b/src/routes/api/v1/domain.ts
@@ -44,6 +44,12 @@ router.post(
   authorize(['companyDomain:create']),
   domainController.createCompanyDomain
 );
+router.get(
+  '/company/:companyId/domains',
+  authenticate,
+  authorize(['domain:read']),
+  domainController.getCompanyDomainsByCompanyId
+);
 router.delete(
   '/company/:companyId/domain/:domainId',
   authenticate,

--- a/src/swagger/openapi.yaml
+++ b/src/swagger/openapi.yaml
@@ -697,6 +697,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /api/v1/domains/company/{companyId}/domains:
+    get:
+      tags:
+        - Domain
+      summary: Get company domains
+      description: |
+        Retrieves all domains associated with a specific company.
+        Requires appropriate access permissions.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: companyId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Company ID
+      responses:
+        '200':
+          description: Domains retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompanyDomainListResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthErrorResponse'
+        '403':
+          description: Insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   # ==================== PERMISSION ====================
   /api/v1/permissions:
     post:
@@ -2285,6 +2328,12 @@ components:
           type: string
           format: date-time
           description: Creation timestamp
+
+    CompanyDomainListResponse:
+      type: array
+      items:
+        $ref: '#/components/schemas/CompanyDomainResponse'
+      description: List of company-domain associations
 
     CreateRolePermissionRequest:
       type: object

--- a/tests/controllers/domainController.test.ts
+++ b/tests/controllers/domainController.test.ts
@@ -469,4 +469,73 @@ describe('DomainController with dependency injection', () => {
       );
     });
   });
+
+  describe('getCompanyDomainsByCompanyId', () => {
+    it('should return all company-domains for a specific company', async () => {
+      const companyId = faker.string.uuid();
+      const companyDomains = [
+        {
+          id: faker.string.uuid(),
+          companyId,
+          domainId: faker.string.uuid(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: faker.string.uuid(),
+          companyId,
+          domainId: faker.string.uuid(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+      const req = { params: { companyId } } as unknown as Request;
+      mockService.getCompanyDomainsByCompanyId.mockResolvedValueOnce(
+        companyDomains
+      );
+
+      await controller.getCompanyDomainsByCompanyId(req, res);
+
+      expect(mockService.getCompanyDomainsByCompanyId).toHaveBeenCalledWith(
+        companyId
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.arrayContaining(companyDomains)
+      );
+      expect((res.json as jest.Mock).mock.calls[0][0]).toHaveLength(2);
+    });
+
+    it('should return empty array if no company-domains found', async () => {
+      const companyId = faker.string.uuid();
+      const req = { params: { companyId } } as unknown as Request;
+      mockService.getCompanyDomainsByCompanyId.mockResolvedValueOnce([]);
+
+      await controller.getCompanyDomainsByCompanyId(req, res);
+
+      expect(mockService.getCompanyDomainsByCompanyId).toHaveBeenCalledWith(
+        companyId
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith([]);
+    });
+
+    it('should return 500 if an unexpected error occurs', async () => {
+      const companyId = faker.string.uuid();
+      const req = { params: { companyId } } as unknown as Request;
+      mockService.getCompanyDomainsByCompanyId.mockRejectedValueOnce(
+        new Error('Database error')
+      );
+
+      await controller.getCompanyDomainsByCompanyId(req, res);
+
+      expect(mockService.getCompanyDomainsByCompanyId).toHaveBeenCalledWith(
+        companyId
+      );
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Database error' })
+      );
+    });
+  });
 });


### PR DESCRIPTION
- Implement new `getCompanyDomainsByCompanyId` method in DomainController for fetching company-specific domains
- Add secure GET route `/api/v1/domains/company/:companyId/domains` with authentication and authorization
- Update OpenAPI spec with new endpoint documentation and CompanyDomainListResponse schema