### PR TITLE
:wrench::lock: Add role assignment validation to restrict ADMIN creation

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -29,9 +29,15 @@ The application implements a 4-layer security model to ensure data isolation bet
 
 ### **Roles and Access**
 
-- **System Admin (ADMIN)** - Global access for administration
-- **Company Manager (MANAGER)** - Management of their company
+- **System Admin (ADMIN)** - Global access for administration (only System Admins can create users with ADMIN role)
+- **Company Manager (MANAGER)** - Management of their company (cannot assign ADMIN role to users)
 - **Standard User (USER)** - Read-only access to their company
+
+### **Role Assignment Security**
+
+- **ADMIN Role Protection**: Only users with `isSystemAdmin: true` can create users with the ADMIN role
+- **Manager Restrictions**: Company Managers cannot elevate privileges to ADMIN level
+- **Permission Escalation Prevention**: Strict validation prevents unauthorized role escalation
 
 ## 🎯 Secured Resources
 

--- a/src/controllers/userManagementController.ts
+++ b/src/controllers/userManagementController.ts
@@ -24,6 +24,13 @@ export class UserManagementController extends BaseController {
   createUser = async (req: Request, res: Response): Promise<Response> => {
     try {
       const data = createUserSchema.parse(req.body);
+
+      // 1. Validate role assignment permissions
+      await this.userManagementService.validateUserRoleCreation(
+        data.roleId,
+        req.user?.isSystemAdmin ?? false
+      );
+
       const user = await this.userManagementService.createUser(data);
 
       // 2. Determine the company assignment

--- a/src/swagger/openapi.yaml
+++ b/src/swagger/openapi.yaml
@@ -1317,6 +1317,9 @@ paths:
       description: |
         Creates a new user with automatic company assignment.
         Requires appropriate administrative permissions.
+
+        **Role Assignment Security**: Only system administrators (users with isSystemAdmin: true)
+        can create users with the ADMIN role. Company managers cannot assign ADMIN privileges.
       security:
         - bearerAuth: []
       requestBody:
@@ -1345,7 +1348,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AuthErrorResponse'
         '403':
-          description: Insufficient permissions
+          description: Insufficient permissions OR attempting to assign ADMIN role without system administrator privileges
           content:
             application/json:
               schema:

--- a/tests/controllers/userManagementController.test.ts
+++ b/tests/controllers/userManagementController.test.ts
@@ -31,6 +31,7 @@ type MockUserManagementService = {
   createUserRole: jest.Mock<Promise<UserRoleResponse>, [CreateUserRoleRequest]>;
   getUserRoleById: jest.Mock<Promise<UserRoleResponse | null>, [string]>;
   deleteUserRole: jest.Mock<Promise<UserRole>, [string]>;
+  validateUserRoleCreation: jest.Mock<Promise<void>, [string, boolean]>;
 };
 
 type MockPasswordService = {
@@ -47,6 +48,7 @@ const mockUserService: MockUserManagementService = {
   createUserRole: jest.fn(),
   getUserRoleById: jest.fn(),
   deleteUserRole: jest.fn(),
+  validateUserRoleCreation: jest.fn(),
 };
 
 const mockPasswordService: MockPasswordService = {
@@ -100,6 +102,7 @@ describe('UserManagementController', () => {
       };
       mockRequest.body = body;
 
+      mockUserService.validateUserRoleCreation.mockResolvedValue(undefined);
       mockUserService.createUser.mockResolvedValue(user);
       mockUserService.createUserRole.mockResolvedValue({
         id: 'user-role-1',
@@ -112,6 +115,10 @@ describe('UserManagementController', () => {
 
       await controller.createUser(mockRequest, mockResponse);
 
+      expect(mockUserService.validateUserRoleCreation).toHaveBeenCalledWith(
+        'role-user-id',
+        false
+      );
       expect(mockUserService.createUser).toHaveBeenCalledWith(body);
       expect(mockUserService.createUserRole).toHaveBeenCalledWith({
         userId: '1',


### PR DESCRIPTION
- Implement role assignment security in user creation to ensure only system admins can assign ADMIN roles
- Update UserManagementService with validateUserRoleCreation method using injected IRoleRepository
- Enhance userManagementController to validate permissions before creating users
- Update security documentation and API specs to reflect new restrictions, preventing privilege escalation