### PR TITLE
🔧 Fix Vercel build errors: restore simple Express app export

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,9 +1,3 @@
-import type { VercelRequest, VercelResponse } from '@vercel/node';
 import app from '../src/index';
 
-export default async function apiHandler(
-  req: VercelRequest,
-  res: VercelResponse
-) {
-  return app(req, res);
-}
+export default app;


### PR DESCRIPTION
- Revert api/index.ts to simple export (app is not callable)
- Vercel automatically wraps Express apps, no manual handler needed
- This fixes 78 TypeScript build errors on Vercel